### PR TITLE
Fix: add missing `addLogChange` to journal

### DIFF
--- a/minigeth/core/state/statedb.go
+++ b/minigeth/core/state/statedb.go
@@ -162,6 +162,8 @@ func (s *StateDB) Error() error {
 }
 
 func (s *StateDB) AddLog(log *types.Log) {
+	s.journal.append(addLogChange{txhash: s.thash})
+
 	log.TxHash = s.thash
 	log.TxIndex = uint(s.txIndex)
 	log.Index = s.logSize


### PR DESCRIPTION
Resolves `WARNING: receipts don't match`.

Just tried to compare with `geth` and found the last missing piece. Now the journal operation is identical to `geth`.