### PR TITLE
Add missing instructions to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cache
 unicorn
 unicorn2
 .*.swp
+venv

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ contracts -- A Merkleized MIPS processor on chain + the challenge logic
 
 ## Usage
 ```
+# build unicorn
+./build_unicorn.sh
+export LIBUNICORN_PATH=$(pwd)/unicorn2/
+
 # build minigeth for MIPS
 (cd mipigo && pip3 install -r requirements.txt && ./build.sh)
 


### PR DESCRIPTION
**Description**

The current README is lacking some details, specifically building [unicorn](https://github.com/unicorn-engine/unicorn) and adding it to the PATH.

This also add `venv` to `.gitignore`.