### PR TITLE
Fixes to README and evm.sh for mipsevm build

### DIFF
--- a/.github/workflows/test_challenge.yml
+++ b/.github/workflows/test_challenge.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Install unicorn
       run: |
         ./build_unicorn.sh
+        echo "LIBUNICORN_PATH=$(pwd)/unicorn2/" >> $GITHUB_ENV
     - name: Install yarn
       run: |
         npm install --global yarn

--- a/.github/workflows/test_mipsevm.yml
+++ b/.github/workflows/test_mipsevm.yml
@@ -29,7 +29,9 @@ jobs:
         minigeth/go-ethereum 13284469
         minigeth/go-ethereum 13284491
     - name: Install Python deps
-      run: pip3 install -r mipigo/requirements.txt
+      run: |
+        pip3 install -r mipigo/requirements.txt
+        (cd unicorn2/bindings/python && python3 setup.py install)
     - name: Build minigeth for embedded
       run: |
         cd mipigo

--- a/.github/workflows/test_mipsevm.yml
+++ b/.github/workflows/test_mipsevm.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Install unicorn
       run: |
         ./build_unicorn.sh
+        echo "LIBUNICORN_PATH=$(pwd)/unicorn2/" >> $GITHUB_ENV
     - name: Install yarn
       run: |
         npm install --global yarn
@@ -29,9 +30,7 @@ jobs:
         minigeth/go-ethereum 13284469
         minigeth/go-ethereum 13284491
     - name: Install Python deps
-      run: |
-        pip3 install -r mipigo/requirements.txt
-        (cd unicorn2/bindings/python && python3 setup.py install)
+      run: pip3 install -r mipigo/requirements.txt
     - name: Build minigeth for embedded
       run: |
         cd mipigo

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@ contracts -- A Merkleized MIPS processor on chain + the challenge logic
 ```
 
 ## Usage
+
+The following commands should be run from the root directory unless otherwise specified:
+
 ```
 yarn
 
 # build unicorn
 ./build_unicorn.sh
+(cd unicorn2/bindings/python && python3 setup.py install)
 export LIBUNICORN_PATH=$(pwd)/unicorn2/
 
 # build minigeth for MIPS
-(cd mipigo && pip3 install -r requirements.txt && ./build.sh)
+(cd mipigo && ./build.sh)
 
 # build minigeth for PC
 (cd minigeth/ && go build)

--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ contracts -- A Merkleized MIPS processor on chain + the challenge logic
 The following commands should be run from the root directory unless otherwise specified:
 
 ```
-# build unicorn
 ./build_unicorn.sh
-(cd unicorn2/bindings/python && python3 setup.py install)
-export LIBUNICORN_PATH=$(pwd)/unicorn2/
 
 # build minigeth for MIPS
 (cd mipigo && ./build.sh)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ contracts -- A Merkleized MIPS processor on chain + the challenge logic
 The following commands should be run from the root directory unless otherwise specified:
 
 ```
-yarn
-
 # build unicorn
 ./build_unicorn.sh
 (cd unicorn2/bindings/python && python3 setup.py install)
@@ -37,20 +35,16 @@ export LIBUNICORN_PATH=$(pwd)/unicorn2/
 # build minigeth for MIPS
 (cd mipigo && ./build.sh)
 
-# build minigeth for PC
-(cd minigeth/ && go build)
-mkdir -p /tmp/cannon
-
 # compute the transition from 13284469 -> 13284470 on PC
+mkdir -p /tmp/cannon
 minigeth/go-ethereum 13284469
 
 # write out the golden MIPS minigeth start state
 yarn
 (cd mipsevm && ./evm.sh)
-./mipsevm/mipsevm
 
 # generate MIPS checkpoints for 13284469 -> 13284470
-./mipsevm/mipsevm 13284469
+mipsevm/mipsevm 13284469
 
 # deploy the MIPS and challenge contracts
 npx hardhat run scripts/deploy.js

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ contracts -- A Merkleized MIPS processor on chain + the challenge logic
 
 ## Usage
 ```
+yarn
+
 # build unicorn
 ./build_unicorn.sh
 export LIBUNICORN_PATH=$(pwd)/unicorn2/
@@ -39,10 +41,12 @@ mkdir -p /tmp/cannon
 minigeth/go-ethereum 13284469
 
 # write out the golden MIPS minigeth start state
-mipsevm/mipsevm
+yarn
+(cd mipsevm && ./evm.sh)
+./mipsevm/mipsevm
 
 # generate MIPS checkpoints for 13284469 -> 13284470
-mipsevm/mipsevm 13284469
+./mipsevm/mipsevm 13284469
 
 # deploy the MIPS and challenge contracts
 npx hardhat run scripts/deploy.js

--- a/build_unicorn.sh
+++ b/build_unicorn.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
-git clone https://github.com/geohot/unicorn.git -b dev unicorn2
-#git clone https://github.com/unicorn-engine/unicorn.git -b dev unicorn2
+if [[ ! -d unicorn2 ]]; then
+    git clone https://github.com/geohot/unicorn.git -b dev unicorn2
+    #git clone https://github.com/unicorn-engine/unicorn.git -b dev unicorn2
+fi
+
 cd unicorn2
-#cmake . -DUNICORN_ARCH=mips -DCMAKE_BUILD_TYPE=Debug
 cmake . -DUNICORN_ARCH=mips -DCMAKE_BUILD_TYPE=Release
+#cmake . -DUNICORN_ARCH=mips -DCMAKE_BUILD_TYPE=Debug
 make -j8
 
+# setting this avoids re-building unicorn in setup.py
+export LIBUNICORN_PATH=$(pwd)
+
+cd bindings/python
+sudo python3 setup.py install

--- a/mipigo/requirements.txt
+++ b/mipigo/requirements.txt
@@ -1,4 +1,3 @@
-unicorn==1.0.3
 pyelftools==0.27
 hexdump==3.3
 termcolor==1.1.0

--- a/mipsevm/evm.sh
+++ b/mipsevm/evm.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 (cd ../ && npx hardhat compile > /dev/null)
-go build && ./mipsevm $@
+go build && ./mipsevm/mipsevm $@
+

--- a/mipsevm/evm.sh
+++ b/mipsevm/evm.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -e
 (cd ../ && npx hardhat compile > /dev/null)
-go build && ./mipsevm/mipsevm $@
-
+go build && (cd .. && ./mipsevm/mipsevm $@)


### PR DESCRIPTION
**Description**

Some modifications to the README and build scripts that, for me at least get everything working. 

Ultimately two things needed to be fixed:
1. Which version of the unicorn bindings to build (the 2.0 package doesn't appear to be hosted on pypi)
2. Some of the paths used to run the commands