### PR TITLE
challenge_fault: attempt to fix timeout

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -18,8 +18,9 @@ module.exports = {
   //defaultNetwork: "hosthat",
   networks: {
     hosthat: {
-      url: "http://localhost:8545/",
-      accounts: ["0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+      url: "http://127.0.0.1:8545/",
+      accounts: ["0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"],
+      timeout: 600_000,
     },
     cheapeth: {
       url: "https://rpc.cheapeth.org/rpc",


### PR DESCRIPTION
**Description**
Fixing the timeout in challenge_fault test that some users hit on Windows. The fix is 2-part:
 * use IP instead of hostname for HH node -> takes DNS out of the picture
 * increase the timeout


**Additional context**
See the linked Issue for full context

**Metadata**
- Fixes [https://github.com/ethereum-optimism/cannon/issues/53](https://github.com/ethereum-optimism/cannon/issues/53)
