### PR TITLE
fix missing `ret` in MIPS.sol

### DIFF
--- a/contracts/MIPS.sol
+++ b/contracts/MIPS.sol
@@ -59,7 +59,7 @@ contract MIPS {
       emit TryReadMemory(addr);
       ret = m.ReadMemory(stateHash, addr);
       //emit DidReadMemory(addr, ret);
-      return;
+      return ret;
     }
     assembly {
       ret := sload(addr)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The change introduced in https://github.com/ethereum-optimism/cannon/commit/e742d9c35f7e0fb4a7b2092bdf574e1f464d014f broke the MIPS.sol contract, this adds a missing `ret` to the return so that MIPS.sol can compile.

**Additional context**


**Metadata**
https://github.com/ethereum-optimism/cannon/commit/e742d9c35f7e0fb4a7b2092bdf574e1f464d014f
