### PR TITLE
Remove mipsevm CLI hardcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test_challenge:
 	minigeth/go-ethereum 13284469
 	# Generate initial (generic) MIPS memory checkpoint and final checkpoint for
 	# block 13284469.
-	mipsevm/mipsevm && mipsevm/mipsevm 13284469
+	mipsevm/mipsevm --outputGolden && mipsevm/mipsevm --blockNumber=13284469
 	npx hardhat test test/challenge_test.js
 .PHONY: test_challenge
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ mkdir -p /tmp/cannon
 minigeth/go-ethereum $TRANSITION_BLOCK
 
 # write out the golden MIPS minigeth start state
-mipsevm/mipsevm
+mipsevm/mipsevm --outputGolden
 
 # if you run into "digital envelope routines::unsupported", rerun after this:
 # export NODE_OPTIONS=--openssl-legacy-provider
 
 # generate MIPS checkpoints
-mipsevm/mipsevm $TRANSITION_BLOCK
+mipsevm/mipsevm --blockNumber=$TRANSITION_BLOCK
 
 # deploy the MIPS and challenge contracts
 npx hardhat run scripts/deploy.js

--- a/demo/challenge_fault.sh
+++ b/demo/challenge_fault.sh
@@ -101,7 +101,7 @@ mkdir -p /tmp/cannon /tmp/cannon_fault && rm -rf /tmp/cannon/* /tmp/cannon_fault
 
 # stored in /tmp/cannon/golden.json
 shout "GENERATING INITIAL MEMORY STATE CHECKPOINT"
-mipsevm/mipsevm
+mipsevm/mipsevm --outputGolden
 
 shout "DEPLOYING CONTRACTS"
 npx hardhat run scripts/deploy.js --network $NETWORK
@@ -113,7 +113,7 @@ shout "FETCHING PREIMAGES FOR REAL BLOCK"
 minigeth/go-ethereum $BLOCK
 
 shout "COMPUTING REAL MIPS FINAL MEMORY CHECKPOINT"
-mipsevm/mipsevm $BLOCK
+mipsevm/mipsevm --blockNumber=$BLOCK
 
 # these are the preimages for the real block (but go into a different basedir)
 shout "FETCHING PREIMAGES FOR FAULTY BLOCK"
@@ -122,10 +122,10 @@ BASEDIR=/tmp/cannon_fault minigeth/go-ethereum $BLOCK
 # since the computation includes a fault, the output file will be different than
 # for the real block
 shout "COMPUTE FAKE MIPS CHECKPOINT"
-OUTPUTFAULT=1 BASEDIR=/tmp/cannon_fault mipsevm/mipsevm $BLOCK
+OUTPUTFAULT=1 BASEDIR=/tmp/cannon_fault mipsevm/mipsevm --blockNumber=$BLOCK
 
 # alternatively, to inject a fault in registers instead of memory
-# REGFAULT=13240000 BASEDIR=/tmp/cannon_fault mipsevm/mipsevm $BLOCK
+# REGFAULT=13240000 BASEDIR=/tmp/cannon_fault mipsevm/mipsevm --blockNumber=$BLOCK
 
 # --- BINARY SEARCH ------------------------------------------------------------
 

--- a/demo/challenge_simple.sh
+++ b/demo/challenge_simple.sh
@@ -97,7 +97,7 @@ mkdir -p /tmp/cannon /tmp/cannon_fault && rm -rf /tmp/cannon/* /tmp/cannon_fault
 
 # stored in /tmp/cannon/golden.json
 shout "GENERATING INITIAL MEMORY STATE CHECKPOINT"
-mipsevm/mipsevm
+mipsevm/mipsevm --outputGolden
 
 shout "DEPLOYING CONTRACTS"
 npx hardhat run scripts/deploy.js --network $NETWORK
@@ -109,13 +109,13 @@ shout "FETCHING PREIMAGES FOR REAL BLOCK"
 minigeth/go-ethereum $BLOCK
 
 shout "COMPUTING REAL MIPS FINAL MEMORY CHECKPOINT"
-mipsevm/mipsevm $BLOCK
+mipsevm/mipsevm --blockNumber=$BLOCK
 
 shout "FETCHING PREIMAGES FOR WRONG BLOCK"
 BASEDIR=/tmp/cannon_fault minigeth/go-ethereum $WRONG_BLOCK
 
 shout "COMPUTING FAKE MIPS FINAL MEMORY CHECKPOINT"
-BASEDIR=/tmp/cannon_fault mipsevm/mipsevm $WRONG_BLOCK
+BASEDIR=/tmp/cannon_fault mipsevm/mipsevm --blockNumber=$WRONG_BLOCK
 
 # pretend the wrong block's input, checkpoints and preimages are the right block's
 ln -s /tmp/cannon_fault/0_$WRONG_BLOCK /tmp/cannon_fault/0_$BLOCK

--- a/mipsevm/main.go
+++ b/mipsevm/main.go
@@ -59,6 +59,7 @@ func main() {
 	lastStep := 1
 	if evm {
 		// TODO: fix this
+		log.Fatal("EVM execution currently not supported")
 		/*ZeroRegisters(ram)
 		LoadMappedFile(programPath, ram, 0)
 		WriteCheckpoint(ram, "/tmp/cannon/golden.json", -1)

--- a/mipsevm/main.go
+++ b/mipsevm/main.go
@@ -34,7 +34,7 @@ func main() {
 		defaultBasedir = "/tmp/cannon"
 	}
 	flag.StringVar(&basedir, "basedir", defaultBasedir, "Directory to read inputs, write outputs, and cache preimage oracle data.")
-	flag.IntVar(&blockNumber, "blockNumber", -1, "For state transition programs (e.g. rollups), used to create a seperate subdirectory in the basedir for each block inputs/outputs and snapshots.")
+	flag.IntVar(&blockNumber, "blockNumber", -1, "For state transition programs (e.g. rollups), used to create a separate subdirectory in the basedir for each block inputs/outputs and snapshots.")
 	flag.IntVar(&target, "target", -1, "Target number of instructions to execute in the trace. If < 0 will execute until termination")
 	flag.StringVar(&programPath, "program", "mipigo/minigeth.bin", "Path to binary file containing the program to run")
 	flag.BoolVar(&evm, "evm", false, "If the program should be executed by a MIPS emulator running inside the EVM. This is much much slower than using the Unicorn emulator but exactly replicates the fault proving environment.")

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -112,7 +112,7 @@ function getTrieAtStep(blockNumberN, step) {
 
   if (!fs.existsSync(fn)) {
     console.log("running mipsevm")
-    child_process.execSync("mipsevm/mipsevm "+blockNumberN.toString()+" "+step.toString(), {stdio: 'inherit'})
+    child_process.execSync("mipsevm/mipsevm --blockNumber="+blockNumberN.toString()+" --target="+step.toString(), {stdio: 'inherit'})
   }
 
   return JSON.parse(fs.readFileSync(fn))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Changes the mipsevm CLI tool to be more flexible. 

It allows for executing binaries other than minigeth by passing them as command line args. It also makes it more explicit what the tool is doing by using named args for the target trace, block number, basedir etc.

`mipsvm/mipsevm --help` now returns:

```shell
Usage of mipsevm/mipsevm:
  -basedir string
    	Directory to read inputs, write outputs, and cache preimage oracle data. (default "/tmp/cannon")
  -blockNumber int
    	For state transition programs (e.g. rollups), used to create a separate subdirectory in the basedir for each block inputs/outputs and snapshots. (default -1)
  -evm
    	If the program should be executed by a MIPS emulator running inside the EVM. This is much much slower than using the Unicorn emulator but exactly replicates the fault proving environment.
  -outputGolden
    	Do not read any inputs and instead produce a snapshot of the state prior to execution. Written to <basedir>/golden.json
  -program string
    	Path to binary file containing the program to run (default "mipigo/minigeth.bin")
  -target int
    	Target number of instructions to execute in the trace. If < 0 will execute until termination (default -1)
```

Defaults have been set so that most existing usage within the repo requires minimal changes.

**Tests**

Existing tests have been updated to use new command line args

