### PR TITLE
add pure and fix typo 0x44

### DIFF
--- a/contracts/src/MIPS.sol
+++ b/contracts/src/MIPS.sol
@@ -308,7 +308,7 @@ contract MIPS {
     return outputState();
   }
 
-  function proofOffset(uint8 proofIndex) internal returns (uint256 offset) {
+  function proofOffset(uint8 proofIndex) internal pure returns (uint256 offset) {
     // A proof of 32 bit memory, with 32-byte leaf values, is (32-5)=27 bytes32 entries.
     // And the leaf value itself needs to be encoded as well. And proof.offset == 390
     offset = 390 + (uint256(proofIndex) * (28*32));
@@ -318,7 +318,7 @@ contract MIPS {
     return offset;
   }
 
-  function readMem(uint32 addr, uint8 proofIndex) internal returns (uint32 out) {
+  function readMem(uint32 addr, uint8 proofIndex) internal pure returns (uint32 out) {
     uint256 offset = proofOffset(proofIndex);
     assembly {
       if and(addr, 3) { revert(0, 0) } // quick addr alignment check
@@ -351,7 +351,7 @@ contract MIPS {
   }
 
   // writeMem writes the value by first overwriting the part of the leaf, and then recomputing the memory merkle root.
-  function writeMem(uint32 addr, uint8 proofIndex, uint32 value) internal {
+  function writeMem(uint32 addr, uint8 proofIndex, uint32 value) internal pure {
     uint256 offset = proofOffset(proofIndex);
     assembly {
       if and(addr, 3) { revert(0, 0) } // quick addr alignment check

--- a/contracts/src/Oracle.sol
+++ b/contracts/src/Oracle.sol
@@ -35,7 +35,7 @@ contract Oracle {
         bytes32 key;
         bytes32 part;
         assembly {
-            size := calldataload(0x44) // len(sig) + len(partOffset) + len(preimage offset) = 4 + 32 + 32 = 0x64
+            size := calldataload(0x44) // len(sig) + len(partOffset) + len(preimage offset) = 4 + 32 + 32 = 0x44
             if iszero(lt(partOffset, add(size, 8))) { // revert if part offset >= size+8 (i.e. parts must be within bounds)
                 revert(0, 0)
             }


### PR DESCRIPTION
1. in MIPS.sol, make proofOffset, readMem, writeMem functions pure.
2. fix typo in Oracle.sol.